### PR TITLE
Enhanced the UI of the Pricing Section 

### DIFF
--- a/src/components/PricingSection.jsx
+++ b/src/components/PricingSection.jsx
@@ -117,7 +117,7 @@ const PricingSection = () => {
           </motion.div>
         </motion.div>
       </div>
-    </motion.section> 
+    </motion.section>  
   )
 }
 

--- a/src/components/PricingSection.jsx
+++ b/src/components/PricingSection.jsx
@@ -14,12 +14,12 @@ const PricingSection = () => {
       variants={fadeIn('up', 0.2)}
       initial="hidden"
       whileInView="show"
-      className="py-20 px-4"
+      className="py-20 px-4 bg-gray-50 "
     >
       <div className="max-w-6xl mx-auto">
         <motion.h2 
           variants={textVariant(0.3)}
-          className="text-3xl md:text-4xl font-bold text-center mb-16"
+          className="rounded-lg py-5 text-3xl md:text-4xl font-bold text-center mb-16"
         >
           Pricing
         </motion.h2>
@@ -31,7 +31,7 @@ const PricingSection = () => {
           {/* Starter Plan */}
           <motion.div 
             variants={fadeIn('right', 0.5)}
-            className="bg-white p-8 rounded-lg shadow-lg"
+            className="py-20 px-4 bg-gradient-to-r from-pink-200 to-blue-100 p-8 rounded-lg shadow-lg"
           >
             <motion.h3 
               variants={fadeIn('up', 0.6)}
@@ -50,7 +50,7 @@ const PricingSection = () => {
           {/* Business Plan */}
           <motion.div 
             variants={fadeIn('left', 0.5)}
-            className="bg-white p-8 rounded-lg shadow-lg"
+            className="py-20 px-4 bg-gradient-to-r from-pink-200 to-blue-100 p-8 rounded-lg shadow-lg"
           >
             <motion.h3 
               variants={fadeIn('up', 0.6)}

--- a/src/components/PricingSection.jsx
+++ b/src/components/PricingSection.jsx
@@ -117,7 +117,7 @@ const PricingSection = () => {
           </motion.div>
         </motion.div>
       </div>
-    </motion.section>
+    </motion.section> 
   )
 }
 


### PR DESCRIPTION
I give styling in the Pricing Section at the homepage.

Previously it was very simple or there was no styling -

<img width="1884" height="929" alt="Screenshot 2025-08-11 134327" src="https://github.com/user-attachments/assets/356da8e2-3e22-4b82-b63b-e1a000b65ce8" />

I done changes is like  this- 

<img width="1903" height="995" alt="Screenshot 2025-08-11 180311" src="https://github.com/user-attachments/assets/7d35f13d-aee7-4c0c-b3ad-ac82a4f3f9f0" />

Please check and merge this PR @adityadomle .
Thanks! 
