### PR TITLE
Hero section tagline Jump start your growth correction

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -24,10 +24,10 @@ const Hero = () => {
   return (
     <section id="home" className="flex flex-col md:flex-row justify-between items-center px-4 sm:px-6 lg:px-8 pt-44 pb-16 container mx-auto">
       {/* Left Column */}
-      <div className="w-full md:w-1/2 space-y-6">
+      <div className="w-full md:w-1/2 space-y-6 pt-24 md:pt-0">
         <motion.div variants={fadeIn('right', 0.2)} initial="hidden" whileInView="show">
           {/* Star badge */}
-          <div className="flex items-center gap-2 bg-gray-50 w-fit px-4 py-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer group">
+          <div className="flex  items-center gap-2 bg-gray-50 w-fit px-4 py-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer group">
             <span className="text-blue-600 group-hover:scale-110 transition-transform">★</span>
             <span className="text-sm font-medium">Jump start your growth</span>
           </div>


### PR DESCRIPTION
This pull request resolves the issue where the Jump Start (Scroll-to-Top) Span was not consistently visible, especially on mobile devices.
Changes include:
Adjusted Span position for better visibility across desktop and mobile views.
Ensured the span  remains visible after scrolling beyond the defined threshold.
Before:
Span was hidden or overlapped on certain screen sizes.
Inconsistent appearance when scrolling.
After:
Span consistently appears when scrolling beyond threshold.
Proper alignment and visibility on mobile & desktop.
I have attached videos of changeg , this is before 

https://github.com/user-attachments/assets/4dfeba7e-d986-4248-bfca-eddf2e69eee1

and after change the 

https://github.com/user-attachments/assets/21cb7254-dd50-4362-8573-87ee7f609d41

@adityadomle , plz review it
