### PR TITLE
feat: Added a new Contributors page #91

### DIFF
--- a/api/githubApi.js
+++ b/api/githubApi.js
@@ -1,0 +1,10 @@
+export async function fetchContributors(owner, repo) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/contributors`;
+  
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch contributors: ${response.status}`);
+  }
+  
+  return await response.json();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "autoprefixer": "^10.4.21",
         "axios": "^1.11.0",
         "chart.js": "^4.4.0",
-        "framer-motion": "^12.4.7",
+        "framer-motion": "^12.23.12",
         "nodemailer": "^7.0.5",
         "postcss": "^8.5.6",
         "react": "^18.3.1",
@@ -2955,13 +2955,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.4.7",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.4.7.tgz",
-      "integrity": "sha512-VhrcbtcAMXfxlrjeHPpWVu2+mkcoR31e02aNSR7OUS/hZAciKa8q6o3YN2mA1h+jjscRsSyKvX6E1CiY/7OLMw==",
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.4.5",
-        "motion-utils": "^12.0.0",
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -4169,18 +4169,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.4.5",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.4.5.tgz",
-      "integrity": "sha512-Q2xmhuyYug1CGTo0jdsL05EQ4RhIYXlggFS/yPhQQRNzbrhjKQ1tbjThx5Plv68aX31LsUQRq4uIkuDxdO5vRQ==",
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.0.0"
+        "motion-utils": "^12.23.6"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.0.0.tgz",
-      "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==",
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "autoprefixer": "^10.4.21",
     "axios": "^1.11.0",
     "chart.js": "^4.4.0",
-    "framer-motion": "^12.4.7",
+    "framer-motion": "^12.23.12",
     "nodemailer": "^7.0.5",
     "postcss": "^8.5.6",
     "react": "^18.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,8 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import useScrollTracking from "./utils/useScrollTracking";
 import useTimeTracking from "./utils/useTimeTracking";
 import { trackPageView } from "./utils/analytics";
+import Contibutors from "./pages/Contibutors";
+
 
 function App() {
   // Initialize analytics tracking hooks
@@ -87,6 +89,8 @@ function App() {
             <Route path="/partner" element={<Partner />} />
             <Route path="/analytics" element={<AnalyticsDashboard />} />
             <Route path="/contact" element={<Contact />} />
+            <Route path="/contributors" element={<Contibutors />} />
+
             <Route path="*" element={<NotFound />} />
           </Routes>
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -17,6 +17,7 @@ const Navbar = () => {
     { href: "/#testimonials", label: "Testimonials" },
     { href: "/analytics", label: "Analytics" },
     { href: "/contact", label: "Contact" },
+    { href: "/contributors", label: "Contributors"}
   ];
 
   // Scroll spy logic
@@ -46,7 +47,7 @@ const Navbar = () => {
       initial="hidden"
       whileInView="show"
       viewport={{ once: true }}
-      className="fixed top-0 left-0 right-0 bg-white/90 backdrop-blur-sm z-50 border-b border-gray-100 shadow-sm"
+      className="fixed top-0 inset-x-0 bg-white/90 backdrop-blur-sm z-50 border-b border-gray-100 shadow-sm"
     >
       <div className="w-full flex justify-between items-center container mx-auto px-4 sm:px-6 lg:px-8 md:h-20 h-16">
         {/* Logo */}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
 @import "tailwindcss";
+
+@theme{
+  --font-roboto: 'Roboto', sans-serif;
+  --color-primary: #2563eb;
+}
 
 html {
   scroll-behavior: smooth;

--- a/src/pages/Contibutors.jsx
+++ b/src/pages/Contibutors.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import { fetchContributors } from "../../api/githubApi";
+import { FaGithub } from "react-icons/fa";
+import { motion } from "framer-motion";
+
+const Contibutors = () => {
+	const [contributors, setContributors] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+
+	useEffect(() => {
+		fetchContributors("adityadomle", "BizFlow")
+			.then((data) => {
+				setContributors(data);
+				setLoading(false);
+			})
+			.catch((err) => {
+				setError(err.message);
+				setLoading(false);
+			});
+	}, []);
+
+	if (loading) return <p>Loading Contributors...</p>;
+	if (error) return <p>Error: {error}</p>;
+
+	return (
+		<motion.main
+			initial={{ opacity: 0, y: 50 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.8, ease: "easeOut" }}
+			className="h-auto mt-25 mx-5 mb-5 font-roboto">
+			<div className="h-auto w-full p-5 bg-white/80 backdrop-blur-2xl z-50 border border-neutral-200 rounded-2xl flex flex-col gap-5">
+				<div className="relative">
+					<h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-neutral-900">
+						Contributors on <span className="text-primary">BizFlow</span>
+					</h1>
+
+					<p className=" items-center text-sm sm:text-md md:text-lg text-neutral-600">
+						They are the reason you can scroll through this wonderful website.
+							<img
+								src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Smilies/Saluting%20Face.png"
+								alt="Saluting Face"
+								className="inline-block size-5 md:size-8"
+							/>
+					</p>
+
+					{/* Underline */}
+					<div className="absolute w-full h-px mt-2 bg-gradient-to-r from-primary to-transparent"></div>
+				</div>
+
+				{/* Contributor-Cards     */}
+				<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-8 md:gap-10">
+					{contributors.map((contributor, idx) => {
+						return (
+							<motion.div
+								initial={{ opacity: 0, y: 30 }}
+								whileInView={{ opacity: 1, y: 0 }}
+								transition={{ duration: 0.4, delay: idx * 0.1 }}
+								viewport={{ once: true }}
+								key={idx}>
+								<a
+									href={contributor.html_url}
+									className=" group flex flex-col justify-center px-5 py-5 sm:py-10 rounded-lg bg-neutral-50 gap-1 sm:gap-2 items-center border border-neutral-200 shadow-lg hover:shadow-lg hover:shadow-primary transition duration-400 hover:bg-white hover:-translate-y-2">
+                                        
+									{/* Avatar */}
+									<img
+										src={contributor.avatar_url}
+										alt="Avatar"
+										className="size-20 md:size-25 rounded-full group-hover:border-2 group-hover:border-primary"></img>
+
+									{/* Github username */}
+									<h2 className="flex items-center gap-2 font-medium text-xl group-hover:bg-primary rounded-3xl transition duration-300 ease-in-out group-hover:text-white p-2">
+										<FaGithub />
+										{contributor.login}
+									</h2>
+
+									{/* Number of contributions */}
+									<p className="text-sm sm:text-md">Contributions: {contributor.contributions}</p>
+								</a>
+							</motion.div>
+						);
+					})}
+				</div>
+			</div>
+		</motion.main>
+	);
+};
+
+export default Contibutors;


### PR DESCRIPTION
**Title:**
Added a new contributors page

**Description:**
This PR adds a new page called contributors where all the contributors contributing to this repo are shown in form of cards and with their github account. The number of contributions are also shown. Users can also see the avatar taken from the github profile. This ensures active participation and appreciation for the contributors.

**Related issue:**
Fixes: https://github.com/adityadomle/BizFlow/issues/91

**Changes made to other files:**
@themes are added in the main.css file to make things easier:
-such as primary for the primary color being used
-roboto font for font usage

**The page is made Responsive with all the cards and the titles and the avatar to fit all the screens**
**This is an updated Pull Request in accordance to the Changes made by the owner.**

<img width="1366" height="728" alt="2" src="https://github.com/user-attachments/assets/ba2bf6ee-bf76-4d82-b025-156a20d80ccb" />
<img width="1366" height="728" alt="3" src="https://github.com/user-attachments/assets/4788defa-574b-464c-896b-49a28c21a794" />
<img width="1366" height="728" alt="4" src="https://github.com/user-attachments/assets/78270d9e-861b-48ee-b4e1-096ec67c0843" />
<img width="1366" height="728" alt="1" src="https://github.com/user-attachments/assets/30f8a8d9-be3c-4c17-bee5-c62ff8de53cb" />
