### PR TITLE
[FIX]: #113 Incorrect Time Zone Mentioned on Contact Page

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -417,7 +417,7 @@ const Contact = () => {
                   </div>
                 </div>
                 <p className="text-xs text-gray-500 mt-4">
-                  * All times are in Pacific Standard Time (PST)
+                  * All times are in Indian Standard Time (IST)
                 </p>
               </div>
 


### PR DESCRIPTION
## Description
This PR fixes the incorrect time zone mentioned on the Contact page.  

The single instance of **PST** has been replaced with **IST (Indian Standard Time)** to reflect the correct local time.  

## Related Issue
Fixes #113  

## Changes Made
- [x] Replaced PST with IST on the Contact page.  
- [x] Verified the time zone display is correct.  
- [x] No other files were modified.  

## Screenshots 
<img width="1264" height="779" alt="Screenshot 2025-08-17 at 10 41 19 PM" src="https://github.com/user-attachments/assets/217241de-3312-427b-a773-a371f379d4e7" />

## Checklist
- [x] I have performed a self-review of my code.  
- [x] My changes are well-documented.  
- [x] I have tested the page to ensure the time zone is displayed correctly.  

## Additional Notes
This change ensures accurate time zone information for users on the Contact page.

