### PR TITLE
Fix: reduce hover animation delay on cards

### DIFF
--- a/src/components/FeaturesSection.jsx
+++ b/src/components/FeaturesSection.jsx
@@ -82,7 +82,7 @@ const FeaturesSection = () => {
             transition={{ duration: 0.6, delay: index * 0.2 }}
             whileHover={{ y: -6, scale: 1.01 }}
             whileTap={{ scale: 0.99 }}
-            className={`flex flex-col items-center p-6 rounded-xl shadow-sm hover:shadow-lg transition-[background,box-shadow,border,color,transform] duration-300 border ${
+            className={`flex flex-col items-center p-6 rounded-xl shadow-sm hover:shadow-lg transition-[background,box-shadow,border,color,transform] ease-in-out duration-10 border ${
               isDarkMode
                 ? "bg-slate-800/70 border-slate-700 backdrop-blur-[1px]"
                 : "bg-white border-gray-100"

--- a/src/components/PurposeSection.jsx
+++ b/src/components/PurposeSection.jsx
@@ -89,7 +89,7 @@ const PurposeSection = () => {
                 whileHover={{ y: -4, scale: 1.005 }}
                 transition={{ type: "spring", stiffness: 220, damping: 18 }}
                 className={`relative flex items-start space-x-4 p-5 rounded-xl border
-                            transition-all duration-300
+                            transition-all ease-in-out duration-10
                             ${
                               isDarkMode
                                 ? "bg-slate-800/60 border-slate-700"


### PR DESCRIPTION
### Related Issue
Fixes: #172 

### Description
This PR improves the user experience by reducing the delay in the hover animation on cards.  
- Changed CSS/Tailwind transition timing from `0.5s` to `0.3s`  
- Added `ease-in-out` for smoother interaction  
- Cards now respond more quickly when hovered, creating a more fluid UI experience.  

### Before
- Hover animation took longer to trigger (felt slightly slow).
- screen recording:-

https://github.com/user-attachments/assets/2a2f8edc-0963-4467-b5fa-42203b6218f8

### After
- Hover animation is faster and smoother (0.3s ease-in-out).  
- Screen recording:-

https://github.com/user-attachments/assets/eb1fd4ce-d932-4a8c-ac10-f3b027f22325

