### PR TITLE
Add GitHub Stats Section  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "postcss": "^8.5.6",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
+        "react-countup": "^6.5.3",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
         "react-joyride": "^3.0.0-7",
@@ -2259,6 +2260,12 @@
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
+    },
+    "node_modules/countup.js": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
+      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4826,6 +4833,18 @@
       "peerDependencies": {
         "chart.js": "^4.1.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-countup": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.5.3.tgz",
+      "integrity": "sha512-udnqVQitxC7QWADSPDOxVWULkLvKUWrDapn5i53HE4DPRVgs+Y5rr4bo25qEl8jSh+0l2cToJgGMx+clxPM3+w==",
+      "license": "MIT",
+      "dependencies": {
+        "countup.js": "^2.8.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "postcss": "^8.5.6",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
+    "react-countup": "^6.5.3",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
     "react-joyride": "^3.0.0-7",

--- a/src/pages/Contibutors.jsx
+++ b/src/pages/Contibutors.jsx
@@ -3,6 +3,7 @@ import { fetchContributors } from "../../api/githubApi";
 import { FaGithub } from "react-icons/fa";
 import { motion } from "framer-motion";
 import { useTheme } from "../context/ThemeContext";
+import GitHubStats from "./GitHubStats";
 
 const Contributors = () => {
   const [contributors, setContributors] = useState([]);
@@ -81,6 +82,10 @@ const Contributors = () => {
             The talented developers behind BizFlow's success
           </motion.p>
         </div>
+        <div className="my-12 px-4">
+  <GitHubStats />
+</div>
+
 
         {/* Contributor Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/src/pages/GitHubStats.jsx
+++ b/src/pages/GitHubStats.jsx
@@ -2,41 +2,51 @@ import { useEffect, useState } from "react";
 import CountUp from "react-countup";
 import { useTheme } from "../context/ThemeContext";
 
+// 🔹 Define the GitHub username and repo we are fetching stats for
 const GITHUB_USER = "adityadomle";
 const GITHUB_REPO = "BizFlow";
 
 export default function GitHubStats() {
-  const { isDarkMode } = useTheme();
+  const { isDarkMode } = useTheme(); // Access current theme (dark/light)
+
+  // 🔹 Store repo stats in local state
   const [stats, setStats] = useState({
-    stars: 0,
-    forks: 0,
-    issues: 0,
-    contributors: 0,
-    lastCommit: "",
-    size: 0,
+    stars: 0, // ⭐ Star count
+    forks: 0, // 🍴 Fork count
+    issues: 0, // 🐛 Open issue count
+    contributors: 0, // 👥 Number of contributors
+    lastCommit: "", // ⏰ Last commit date
+    size: 0, // 💾 Repo size in KB
   });
 
+  // 🔹 Fetch GitHub stats when component mounts
   useEffect(() => {
     async function fetchGitHubStats() {
       try {
+        // 🔑 Use GitHub API token if provided (to avoid rate limits)
         const token = import.meta.env.VITE_GITHUB_TOKEN;
         const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
+        // 📦 Fetch main repo data (stars, forks, issues, last commit, size)
         const repoRes = await fetch(
           `https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}`,
           { headers }
         );
         const repoData = await repoRes.json();
 
+        // 👥 Fetch contributor count using GitHub’s pagination "Link" header
         const contributorsRes = await fetch(
           `https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/contributors?per_page=1&anon=true`,
           { headers }
         );
+
+        // Extract last page number from pagination headers → contributor count
         const contributorsCount =
           contributorsRes.headers
             .get("Link")
             ?.match(/&page=(\d+)>; rel="last"/)?.[1] || 0;
 
+        // ✅ Update local state with fetched values
         setStats({
           stars: repoData.stargazers_count || 0,
           forks: repoData.forks_count || 0,
@@ -46,19 +56,22 @@ export default function GitHubStats() {
           size: repoData.size || 0,
         });
       } catch (err) {
+        // 🚨 Handle network or API errors gracefully
         console.error("Error fetching GitHub stats:", err);
       }
     }
 
+    // 🔹 Trigger fetch function
     fetchGitHubStats();
   }, []);
 
+  // 🔹 Define all stat cards with labels, values, icons & GitHub links
   const statCards = [
     {
-      label: "Stars",
-      value: stats.stars,
-      icon: "⭐",
-      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/stargazers`,
+      label: "Stars", // Title
+      value: stats.stars, // Data
+      icon: "⭐", // Emoji icon
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/stargazers`, // Link to repo stars
     },
     {
       label: "Forks",
@@ -93,6 +106,7 @@ export default function GitHubStats() {
   ];
 
   return (
+    // 🔹 Section wrapper with dynamic dark/light styling
     <section
       className={`py-20 px-6 rounded-2xl border ${
         isDarkMode
@@ -101,6 +115,7 @@ export default function GitHubStats() {
       }`}
     >
       <div className="max-w-7xl mx-auto text-center">
+        {/* 🔹 Section heading with gradient underline */}
         <h3
           className={`relative text-3xl sm:text-4xl font-bold mb-14 tracking-tight inline-block ${
             isDarkMode ? "text-white" : "text-gray-900"
@@ -110,8 +125,10 @@ export default function GitHubStats() {
           <span className="absolute left-0 -bottom-2 w-full h-1 rounded-full bg-gradient-to-r from-blue-500 to-transparent"></span>
         </h3>
 
+        {/* 🔹 Responsive grid layout for stats (2 → 6 columns) */}
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8">
           {statCards.map(({ label, value, icon, link }) => (
+            // 🔹 Each stat card is clickable → navigates to GitHub
             <a
               key={label}
               href={link}
@@ -123,18 +140,23 @@ export default function GitHubStats() {
                   : "bg-white text-gray-900 border-transparent shadow-[0_0_25px_rgba(59,130,246,0.25)] hover:shadow-[0_0_35px_rgba(59,130,246,0.35)]"
               }`}
             >
+              {/* 🔹 Emoji icon */}
               <div className="text-4xl mb-3">{icon}</div>
+
+              {/* 🔹 Animated number counter (CountUp for smooth effect) */}
               <div
                 className={`text-2xl font-semibold ${
                   isDarkMode ? "text-white" : "text-gray-900"
                 }`}
               >
                 {typeof value === "number" ? (
-                  <CountUp end={value} duration={1.5} />
+                  <CountUp end={value} duration={1.5} /> // Animation only for numbers
                 ) : (
-                  value
+                  value // Render as plain text if not a number (ex: last commit date)
                 )}
               </div>
+
+              {/* 🔹 Card label with hover color change */}
               <div
                 className={`mt-2 text-sm font-medium ${
                   isDarkMode

--- a/src/pages/GitHubStats.jsx
+++ b/src/pages/GitHubStats.jsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import CountUp from "react-countup";
+import { useTheme } from "../context/ThemeContext";
+
+const GITHUB_USER = "adityadomle";
+const GITHUB_REPO = "BizFlow";
+
+export default function GitHubStats() {
+  const { isDarkMode } = useTheme();
+  const [stats, setStats] = useState({
+    stars: 0,
+    forks: 0,
+    issues: 0,
+    contributors: 0,
+    lastCommit: "",
+    size: 0,
+  });
+
+  useEffect(() => {
+    async function fetchGitHubStats() {
+      try {
+        const token = import.meta.env.VITE_GITHUB_TOKEN;
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+        const repoRes = await fetch(
+          `https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}`,
+          { headers }
+        );
+        const repoData = await repoRes.json();
+
+        const contributorsRes = await fetch(
+          `https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/contributors?per_page=1&anon=true`,
+          { headers }
+        );
+        const contributorsCount =
+          contributorsRes.headers
+            .get("Link")
+            ?.match(/&page=(\d+)>; rel="last"/)?.[1] || 0;
+
+        setStats({
+          stars: repoData.stargazers_count || 0,
+          forks: repoData.forks_count || 0,
+          issues: repoData.open_issues_count || 0,
+          contributors: contributorsCount || 0,
+          lastCommit: new Date(repoData.pushed_at).toLocaleDateString(),
+          size: repoData.size || 0,
+        });
+      } catch (err) {
+        console.error("Error fetching GitHub stats:", err);
+      }
+    }
+
+    fetchGitHubStats();
+  }, []);
+
+  const statCards = [
+    {
+      label: "Stars",
+      value: stats.stars,
+      icon: "⭐",
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/stargazers`,
+    },
+    {
+      label: "Forks",
+      value: stats.forks,
+      icon: "🍴",
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/network/members`,
+    },
+    {
+      label: "Issues",
+      value: stats.issues,
+      icon: "🐛",
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/issues`,
+    },
+    {
+      label: "Contributors",
+      value: stats.contributors,
+      icon: "👥",
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/graphs/contributors`,
+    },
+    {
+      label: "Last Commit",
+      value: stats.lastCommit,
+      icon: "⏰",
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/commits`,
+    },
+    {
+      label: "Repo Size (KB)",
+      value: stats.size,
+      icon: "💾",
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}`,
+    },
+  ];
+
+  return (
+    <section
+      className={`py-20 px-6 rounded-2xl border ${
+        isDarkMode
+          ? "bg-gray-900 text-white border-white/10 shadow-[0_0_20px_rgba(255,255,255,0.08)]"
+          : "bg-gray-50 text-gray-900 border-transparent shadow-[0_0_25px_rgba(59,130,246,0.25)]"
+      }`}
+    >
+      <div className="max-w-7xl mx-auto text-center">
+        <h3
+          className={`relative text-3xl sm:text-4xl font-bold mb-14 tracking-tight inline-block ${
+            isDarkMode ? "text-white" : "text-gray-900"
+          }`}
+        >
+          Project Stats
+          <span className="absolute left-0 -bottom-2 w-full h-1 rounded-full bg-gradient-to-r from-blue-500 to-transparent"></span>
+        </h3>
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8">
+          {statCards.map(({ label, value, icon, link }) => (
+            <a
+              key={label}
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`group p-6 rounded-xl transition-all duration-300 transform hover:-translate-y-1 flex flex-col items-center justify-center border ${
+                isDarkMode
+                  ? "bg-gray-800/60 text-white border-white/10 shadow-[0_0_20px_rgba(255,255,255,0.08)] hover:shadow-[0_0_30px_rgba(255,255,255,0.15)]"
+                  : "bg-white text-gray-900 border-transparent shadow-[0_0_25px_rgba(59,130,246,0.25)] hover:shadow-[0_0_35px_rgba(59,130,246,0.35)]"
+              }`}
+            >
+              <div className="text-4xl mb-3">{icon}</div>
+              <div
+                className={`text-2xl font-semibold ${
+                  isDarkMode ? "text-white" : "text-gray-900"
+                }`}
+              >
+                {typeof value === "number" ? (
+                  <CountUp end={value} duration={1.5} />
+                ) : (
+                  value
+                )}
+              </div>
+              <div
+                className={`mt-2 text-sm font-medium ${
+                  isDarkMode
+                    ? "text-gray-300 group-hover:text-accent-400"
+                    : "text-gray-600 group-hover:text-indigo-600"
+                }`}
+              >
+                {label}
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 🚀 PR: Add GitHub Stats Section  

### 📌 Description  
This PR introduces a new **GitHub Stats** section that displays real-time project statistics in a clean and responsive card layout.  
It helps contributors and visitors quickly get insights into the project’s growth and activity.  

---

Fixes Issue : #272

---


### 🛠 Changes Made  
- Created a new `<GitHubStats />` component.  
- Added **stat cards** (stars, forks, contributors, issues, PRs, commits, etc.) with hover effects and smooth transitions.  
- Implemented **dark mode support** with proper background, text, and shadow styles.  
- Styled section heading **"Project Stats"** with a **blue gradient underline** that fades to the right.  
- Used `CountUp` animation for stat values to make the section more dynamic.  
- Added subtle hover ring and shadow effects for interactivity.  

---

### 🎨 UI Enhancements  
- Light mode → white cards with **blue shadow + hover accent**.  
- Dark mode → semi-transparent dark cards with **thin white border + glow effect**.  
- Responsive grid layout (2 → 6 columns based on screen size).  

---

### ✅ Outcome  
The GitHub Stats section is now more **interactive, visually appealing, and informative**, giving users a quick overview of project activity.  

Screenshot--
<img width="1880" height="757" alt="image" src="https://github.com/user-attachments/assets/34d7d8d2-a01c-4758-a244-4ef87e375c9a" />
<img width="1717" height="567" alt="image" src="https://github.com/user-attachments/assets/978e656e-9f56-4729-8c07-7491b5dd2603" />
<img width="1861" height="771" alt="image" src="https://github.com/user-attachments/assets/7e1de36a-e9ec-436e-8b51-216737f9edb0" />
<img width="1717" height="551" alt="image" src="https://github.com/user-attachments/assets/836d2819-0fb1-4c84-89a1-78af5806ed43" />
<img width="1878" height="1023" alt="image" src="https://github.com/user-attachments/assets/5501bf4f-399b-4607-9b9a-ae09648dbba8" />

---
