### PR TITLE
Add Dynamic GSSoC'25 Leaderboard 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ const NotFound = lazy(() => import("./components/NotFound"));
 const Contact = lazy(() => import("./components/Contact"));
 const FAQ = lazy(() => import("./components/FAQ"));
 
+
 // Lazy loaded pages
 const Partner = lazy(() => import("./pages/Partner"));
 const Contibutors = lazy(() => import("./pages/Contibutors"));
@@ -34,6 +35,7 @@ const SupportCareer = lazy(() => import("./pages/SupportCareer"));
 const PrivacyPolicyPage = lazy(() => import("./pages/PrivacyPolicyPage"));
 const TermsOfUsePage = lazy(() => import("./pages/TermsOfUsePage"));
 const ContributorGuide = lazy(() => import("./pages/ContributorGuide"));
+const LeaderBoard = lazy(() => import("./pages/LeaderBoard"));
 
 // Router
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
@@ -149,6 +151,8 @@ function AppContent() {
             <Route path="/contact" element={<Contact />} />
             <Route path="/contributors" element={<Contibutors />} />
             <Route path="/contributor-guide" element={<ContributorGuide />} />
+            <Route path="/leaderboard" element={<LeaderBoard />} />
+
             <Route path="/support-career" element={<SupportCareer />} />
             <Route path="/faqs" element={<FAQ />} />
             <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -82,6 +82,12 @@ const ModernNavbar = () => {
       label: "Contributor Guide", 
       icon: "📖",
       description: "Learn how to contribute"
+    },
+    { 
+      href: "/leaderboard", 
+      label: "LeaderBoard", 
+      icon: "🏆",
+      description: "Check your rank"
     }
   ], []);
 

--- a/src/pages/LeaderBoard.jsx
+++ b/src/pages/LeaderBoard.jsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { FaTrophy, FaMedal, FaCode, FaStar } from "react-icons/fa";
+import { useTheme } from "../context/ThemeContext";
+
+const GITHUB_REPO = "adityadomle/BizFlow";
+const TOKEN = import.meta.env.VITE_GITHUB_TOKEN || "";
+
+const POINTS = {
+  level1: 3,
+  level2: 7,
+  level3: 10,
+};
+
+export default function LeaderBoard() {
+  const [contributors, setContributors] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const { isDarkMode } = useTheme();
+
+  useEffect(() => {
+    const fetchContributors = async () => {
+      try {
+        let contributorsMap = {};
+        let page = 1;
+        let hasMore = true;
+
+        while (hasMore) {
+          const res = await fetch(
+            `https://api.github.com/repos/${GITHUB_REPO}/pulls?state=closed&per_page=100&page=${page}`,
+            { headers: TOKEN ? { Authorization: `token ${TOKEN}` } : {} }
+          );
+
+          const prs = await res.json();
+          if (prs.length === 0) {
+            hasMore = false;
+            break;
+          }
+
+          prs.forEach((pr) => {
+            if (!pr.merged_at) return;
+            const labels = pr.labels.map((l) => l.name.toLowerCase());
+            if (!labels.includes("gssoc25")) return;
+
+            const author = pr.user.login;
+            let points = 0;
+            labels.forEach((label) => {
+              const normalized = label.replace(/\s+/g, "").toLowerCase();
+              if (POINTS[normalized]) points += POINTS[normalized];
+            });
+
+            if (!contributorsMap[author]) {
+              contributorsMap[author] = {
+                username: author,
+                avatar: pr.user.avatar_url,
+                profile: pr.user.html_url,
+                points: 0,
+                prs: 0,
+              };
+            }
+            contributorsMap[author].points += points;
+            contributorsMap[author].prs += 1;
+          });
+
+          page++;
+        }
+
+        setContributors(
+          Object.values(contributorsMap).sort((a, b) => b.points - a.points)
+        );
+      } catch (err) {
+        console.error("Error fetching contributors:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchContributors();
+  }, []);
+
+  return (
+    <div
+      className={`py-20 px-6 rounded-2xl border backdrop-blur-md ${
+        isDarkMode
+          ? "bg-gray-900/70 text-white border-white/10 shadow-[0_0_30px_rgba(255,255,255,0.08)]"
+          : "bg-gray-50/70 text-gray-900 border-transparent shadow-[0_0_30px_rgba(59,130,246,0.25)]"
+      }`}
+    >
+      <motion.div
+        className="text-center mb-12"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+      >
+        <h1 className="text-5xl font-extrabold bg-gradient-to-r from-blue-700 via-blue-500 to-blue-300 bg-clip-text text-transparent mb-3 drop-shadow-lg mt-6">
+          GSSoC'25 Leaderboard
+        </h1>
+        <p className="text-lg opacity-80">
+          Celebrating the amazing contributions 🚀
+        </p>
+      </motion.div>
+
+      {loading ? (
+        <p className="text-center opacity-70">Loading contributors...</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-separate border-spacing-y-3">
+            {/* Table Header */}
+            <thead>
+              <tr
+                className={`text-left text-sm uppercase ${
+                  isDarkMode ? "text-gray-400" : "text-gray-600"
+                }`}
+              >
+                <th className="px-6 py-3">Rank</th>
+                <th className="px-6 py-3">Contributor</th>
+                <th className="px-6 py-3">Contributions</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {contributors.map((c, index) => (
+                <motion.tr
+                  key={c.username}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3, delay: index * 0.03 }}
+                  className={`rounded-xl transition-all duration-300 ${
+                    isDarkMode
+                      ? "bg-gray-800/60 hover:bg-gradient-to-r hover:from-purple-600/30 hover:to-blue-600/30"
+                      : "bg-white/70 hover:bg-gradient-to-r hover:from-blue-100 hover:to-pink-100"
+                  }`}
+                >
+                  {/* Rank */}
+                  <td className="px-6 py-4 font-semibold">
+                    {index === 0 ? (
+                      <FaTrophy className="text-yellow-400 text-2xl drop-shadow-md animate-pulse" />
+                    ) : index === 1 ? (
+                      <FaMedal className="text-gray-300 text-2xl drop-shadow" />
+                    ) : index === 2 ? (
+                      <FaMedal className="text-amber-600 text-2xl drop-shadow" />
+                    ) : (
+                      <span className="text-lg">{index + 1}</span>
+                    )}
+                  </td>
+
+                  {/* Contributor Info */}
+                  <td className="px-6 py-4 flex items-center space-x-4">
+                    <img
+                      src={c.avatar}
+                      alt={c.username}
+                      className="w-11 h-11 rounded-full border-2 border-indigo-400 shadow-md"
+                    />
+                    <a
+                      href={c.profile}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium hover:underline text-lg"
+                    >
+                      {c.username}
+                    </a>
+                  </td>
+
+                  {/* Stats (Points + PRs in one line) */}
+                  <td className="px-6 py-4 flex items-center gap-6 text-lg font-semibold">
+                    <span className="flex items-center gap-2 text-yellow-500">
+                      <FaStar /> {c.points}
+                    </span>
+                    <span className="opacity-50">|</span>
+                    <span className="flex items-center gap-2 text-indigo-500">
+                      <FaCode /> {c.prs}
+                    </span>
+                  </td>
+                </motion.tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/LeaderBoard.jsx
+++ b/src/pages/LeaderBoard.jsx
@@ -105,74 +105,77 @@ export default function LeaderBoard() {
         <div className="overflow-x-auto">
           <table className="min-w-full border-separate border-spacing-y-3">
             {/* Table Header */}
-            <thead>
-              <tr
-                className={`text-left text-sm uppercase ${
-                  isDarkMode ? "text-gray-400" : "text-gray-600"
-                }`}
-              >
-                <th className="px-6 py-3">Rank</th>
-                <th className="px-6 py-3">Contributor</th>
-                <th className="px-6 py-3">Contributions</th>
-              </tr>
-            </thead>
+            {/* Table Header */}
+<thead>
+  <tr
+    className={`text-left text-sm uppercase ${
+      isDarkMode ? "text-gray-400" : "text-gray-600"
+    }`}
+  >
+    <th className="px-6 py-3">Rank</th>
+    <th className="px-6 py-3">Contributor</th>
+    <th className="px-6 py-3">Contributions</th>
+  </tr>
+</thead>
 
-            <tbody>
-              {contributors.map((c, index) => (
-                <motion.tr
-                  key={c.username}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.3, delay: index * 0.03 }}
-                  className={`rounded-xl transition-all duration-300 ${
-                    isDarkMode
-                      ? "bg-gray-800/60 hover:bg-gradient-to-r hover:from-purple-600/30 hover:to-blue-600/30"
-                      : "bg-white/70 hover:bg-gradient-to-r hover:from-blue-100 hover:to-pink-100"
-                  }`}
-                >
-                  {/* Rank */}
-                  <td className="px-6 py-4 font-semibold">
-                    {index === 0 ? (
-                      <FaTrophy className="text-yellow-400 text-2xl drop-shadow-md animate-pulse" />
-                    ) : index === 1 ? (
-                      <FaMedal className="text-gray-300 text-2xl drop-shadow" />
-                    ) : index === 2 ? (
-                      <FaMedal className="text-amber-600 text-2xl drop-shadow" />
-                    ) : (
-                      <span className="text-lg">{index + 1}</span>
-                    )}
-                  </td>
+<tbody>
+  {contributors.map((c, index) => (
+    <motion.tr
+      key={c.username}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, delay: index * 0.03 }}
+      className={`rounded-xl transition-all duration-300 ${
+        isDarkMode
+          ? "bg-gray-800/60 hover:bg-gradient-to-r hover:from-purple-600/30 hover:to-blue-600/30"
+          : "bg-white/70 hover:bg-gradient-to-r hover:from-blue-100 hover:to-pink-100"
+      }`}
+    >
+      {/* Rank */}
+      <td className="px-6 py-4 font-semibold">
+        {index === 0 ? (
+          <FaTrophy className="text-yellow-400 text-2xl drop-shadow-md animate-pulse" />
+        ) : index === 1 ? (
+          <FaMedal className="text-gray-300 text-2xl drop-shadow" />
+        ) : index === 2 ? (
+          <FaMedal className="text-amber-600 text-2xl drop-shadow" />
+        ) : (
+          <span className="text-lg">{index + 1}</span>
+        )}
+      </td>
 
-                  {/* Contributor Info */}
-                  <td className="px-6 py-4 flex items-center space-x-4">
-                    <img
-                      src={c.avatar}
-                      alt={c.username}
-                      className="w-11 h-11 rounded-full border-2 border-indigo-400 shadow-md"
-                    />
-                    <a
-                      href={c.profile}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="font-medium hover:underline text-lg"
-                    >
-                      {c.username}
-                    </a>
-                  </td>
+      {/* Contributor Info */}
+      <td className="px-6 py-4 flex items-center space-x-4">
+        <img
+          src={c.avatar}
+          alt={c.username}
+          className="w-11 h-11 rounded-full border-2 border-indigo-400 shadow-md"
+        />
+        <a
+          href={c.profile}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium hover:underline text-lg"
+        >
+          {c.username}
+        </a>
+      </td>
 
-                  {/* Stats (Points + PRs in one line) */}
-                  <td className="px-6 py-4 flex items-center gap-6 text-lg font-semibold">
-                    <span className="flex items-center gap-2 text-yellow-500">
-                      <FaStar /> {c.points}
-                    </span>
-                    <span className="opacity-50">|</span>
-                    <span className="flex items-center gap-2 text-indigo-500">
-                      <FaCode /> {c.prs}
-                    </span>
-                  </td>
-                </motion.tr>
-              ))}
-            </tbody>
+      {/* Contributions → Points + PRs inline */}
+      <td className="px-6 py-4">
+        <div className="flex items-center gap-6 text-lg font-semibold">
+          <span className="flex items-center gap-2 text-yellow-500">
+            <FaStar /> {c.points}
+          </span>
+          <span className="flex items-center gap-2 text-indigo-500">
+            <FaCode /> {c.prs}
+          </span>
+        </div>
+      </td>
+    </motion.tr>
+  ))}
+</tbody>
+
           </table>
         </div>
       )}


### PR DESCRIPTION
## 📌 Pull Request: Add Dynamic GSSoC'25 Leaderboard  

### 🚀 Features Added  
- Implemented a **dynamic leaderboard** that fetches contributors from the GitHub API.  
- Contributors are ranked based on their **points** (calculated using PR labels).  
- **PRs & Points displayed inline** as `Points | PRs` for a modern compact look.  
- Added **icons** (🏆, 🥇, ⭐, 💻) to make the leaderboard more engaging and visually appealing.  
- Responsive and theme-aware design:
  - **Dark mode**: sleek glassmorphic style with glowing shadows.  
  - **Light mode**: soft gradient hover effects.  
- **Animated rows** using `framer-motion` for smooth appearance.  
---

### ⚡ Improvements  
- Clear **rank distinction**:  
  - 🏆 Trophy for 1st place.  
  - 🥈 Silver medal for 2nd place.  
  - 🥉 Bronze medal for 3rd place.  
- Contributors are linked to their **GitHub profiles**.  
- Enhanced table UI with hover gradients and smooth transitions.  

---

Fixes Issue: #271 

---

### 🔑 Setup  
- Replace your **GitHub token** inside `.env` as:  
  ```env
  VITE_GITHUB_TOKEN=your_token_here


----

Screenshot--
<img width="1882" height="1015" alt="image" src="https://github.com/user-attachments/assets/177e9c9e-f157-4a59-9792-b8d7c6dac740" />
<img width="1886" height="1021" alt="image" src="https://github.com/user-attachments/assets/d7c44d59-df62-49ef-ae8e-fe7be3984a5d" />
<img width="1882" height="1027" alt="image" src="https://github.com/user-attachments/assets/848d2485-36c2-432e-816f-c6982f35ca75" />
---
