### PR TITLE
Fixed the clipping of the Pricing Plans

### DIFF
--- a/src/components/PricingSection.jsx
+++ b/src/components/PricingSection.jsx
@@ -192,7 +192,7 @@ const PricingSection = () => {
             initial="hidden"
             whileInView="show"
             viewport={{ once: true, margin: "-50px" }}
-            className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-purple-600 bg-clip-text text-transparent"
+            className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-purple-600 bg-clip-text text-transparent leading-normal"
           >
             Pricing Plans
           </motion.h2>


### PR DESCRIPTION
### Related Issue
Closes #268 

### Description
This PR fixes the clipping issue with the **"Pricing Plans"** heading .

### Changes Made
- Removed the clipping of the heading.
- Ensured heading container allows full rendering with `overflow-visible`.

### Before
- Heading text appeared cropped/clipped at the top.

### After
- Heading text displays correctly without clipping.
- Gradient effect remains intact.

Screenshot:-
<img width="1861" height="694" alt="Screenshot 2025-08-29 202054" src="https://github.com/user-attachments/assets/5867be9c-abe8-4292-9bb2-885c90fbce44" />


