### PR TITLE
[FIX]: #314 Pricing Plans Section Appears Lighter in Shade 

### DIFF
--- a/src/components/PricingSection.jsx
+++ b/src/components/PricingSection.jsx
@@ -151,6 +151,7 @@ const PricingCard = ({ name, price, features, animation, isDarkMode }) => {
         scrollTrigger: {
           trigger: el,
           start: "top 80%",
+          end: "top 60%",  
           scrub:true
         },
       }


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #314  

---

## Rationale for this change
The Pricing Plans section appeared **lighter in shade** when scrolled into view, creating the impression of an inactive or broken section.  
This happened because the GSAP + ScrollTrigger animation did not fully restore the intended opacity during the scroll event.  

Additionally, the Pricing Plans **header** and **cards** are implemented as two separate components.  
GSAP was applying animations on them separately, which caused a measurement and sync issue between their scroll triggers.  
Instead of merging them into one component, I resolved the problem by adjusting the animation’s `end` effect.  
This ensures that both elements fade in smoothly and appear visually consistent.

---

## What changes are included in this PR?
- Adjusted scroll boundaries:
  - **Start**: when the top of the section reaches 80% of viewport height.
  - **End**: when the top of the section reaches 60% of viewport height (20% scroll distance).
-  Ensured the section locks in place at full opacity after reaching the scroll threshold.

```jsx
useEffect(() => {
  const el = cardRef.current;
  if (!el) return;

  gsap.fromTo(
        ...
        end: "top 60%",  <--- changes made
        scrub: true
        ...
}, []);
```


## Are these changes tested?

✅ Manually tested in the browser:
   - Section now fades in correctly as the user scrolls.
   - No lighter-shade effect remains after the section becomes active.
   - Smooth fade-in and upward motion observed consistently.


## Are there any user-facing changes?
Yes.
Users will now experience the Pricing Plans section appearing with the intended opacity and smooth scroll-based fade-in, removing the distracting lighter-shade effect.

## Screenshots

*before*

https://github.com/user-attachments/assets/6e45b632-8090-4b7b-b92a-736dbfc00ea6



*after*

https://github.com/user-attachments/assets/ca3fc0e3-f9f1-40f3-a796-ff6bf04bf38b

