### PR TITLE
Fixed About link in footer to redirect to About page.

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -83,7 +83,7 @@ const Footer = () => {
 
   const footerLinks = {
     company: [
-      { name: "About", href: "/#about" },
+      { name: "About", href: "/about" },
       { name: "Terms of Use", href: "/terms-of-use" },
       { name: "Privacy Policy", href: "/privacy-policy" },
       { name: "How it Works", href: "/#SCHEDULE" },


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #325 

## Rationale for this change

The About link in the footer was previously redirecting to the Home page, instead of the About page.

## What changes are included in this PR?

Updated About footer link to redirect to the actual About page, just like the About tab in the Nav Bar.

## Are these changes tested?

Yes.

Kindly review and merge the PR @adityadomle and add the Level 1 label.