### PR TITLE
[FIX]: #326 Page titles not updating on route change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -106,9 +106,51 @@ function AppContent() {
   useScrollTracking();
   useTimeTracking();
 
-  // Track page views on route changes
   useEffect(() => {
     const currentPath = location.pathname;
+    let pageTitle = "BizFlow"; // default
+
+    switch (currentPath) {
+      case "/":
+        pageTitle = "Home | BizFlow";
+        break;
+      case "/partner":
+        pageTitle = "Partner | BizFlow";
+        break;
+      case "/about":
+        pageTitle = "About Us | BizFlow";
+        break;
+      case "/contact":
+        pageTitle = "Contact | BizFlow";
+        break;
+      case "/contributors":
+        pageTitle = "Contributors | BizFlow";
+        break;
+      case "/contributor-guide":
+        pageTitle = "Contributor Guide | BizFlow";
+        break;
+      case "/leaderboard":
+        pageTitle = "Leaderboard | BizFlow";
+        break;
+      case "/support-career":
+        pageTitle = "Support Career | BizFlow";
+        break;
+      case "/faqs":
+        pageTitle = "FAQs | BizFlow";
+        break;
+      case "/privacy-policy":
+        pageTitle = "Privacy Policy | BizFlow";
+        break;
+      case "/terms-of-use":
+        pageTitle = "Terms of Use | BizFlow";
+        break;
+      default:
+        pageTitle = "Page Not Found | BizFlow";
+    }
+
+    document.title = pageTitle;
+
+    // also keep your analytics
     const pageName =
       currentPath === "/"
         ? "Home"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #326

## Rationale for this change

Currently, all routes in the app display the same static page title. This creates a poor user experience and makes it harder for users to distinguish between open tabs. The fix dynamically updates the document title based on the active route.

## What changes are included in this PR?

- Added a `useEffect` hook in `AppContent` to listen for `location.pathname` changes.  
- Implemented a route-to-title mapping logic that sets `document.title` appropriately (e.g., `Home | My App`, `About | My App`, etc.).  
- Kept analytics tracking logic intact while adding the title updates.  

## Are these changes tested?

- Verified manually by navigating across routes (`/`, `/about`, `/partner`, etc.) and confirming that the browser tab updates with the correct title.  
- Since this is a UI-side document title update, existing automated tests do not cover it. No breaking changes to existing tests.  

## Are there any user-facing changes?

- ✅ Yes: Users will now see accurate, descriptive titles in the browser tab for each route.  
- ❌ No breaking changes introduced.  


https://github.com/user-attachments/assets/8594a0ef-7b48-4dc7-91a0-ea453f156897


