### PR TITLE
Fix: corrected extra margin issue in about page hero section

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -142,7 +142,7 @@ const AboutUs = () => {
       >
         <motion.div variants={textVariant(0.3)} className="max-w-4xl mx-auto">
           <h1
-            className={`text-4xl md:text-5xl lg:text-6xl font-bold leading-tight mt-40 relative inline-block ${
+            className={`text-4xl md:text-5xl lg:text-6xl font-bold leading-tight mt-8 relative inline-block ${
               isDarkMode ? "text-white" : "text-gray-900"
             }`}
           >
@@ -159,7 +159,7 @@ const AboutUs = () => {
           </h1>
 
           <p
-            className={`text-lg max-w-3xl mt-10 mb-50 text-center mx-auto ${
+            className={`text-lg max-w-3xl mt-10 text-center mx-auto ${
               isDarkMode ? "text-gray-300" : "text-gray-700"
             }`}
           >
@@ -177,9 +177,9 @@ const AboutUs = () => {
         animate="show"
         className="section-container"
       >
-        <div>
+       
           <div
-            className={`p-8 rounded-3xl transition-all duration-500
+            className={`p-8 mt-20 rounded-3xl transition-all duration-500
         ${
           isDarkMode
             ? "bg-gray-700/20 backdrop-blur-md shadow-[0_0_2px_rgba(139,92,246,0.6)] animate-glow"
@@ -187,7 +187,7 @@ const AboutUs = () => {
         }`}
           >
             <h2
-              className={`inline-block text-xl font-semibold px-6 py-3 rounded-full tracking-wide mb-5
+              className={`inline-block text-xl font-semibold px-6 py-3 rounded-full tracking-wide mb-4
           ${
             isDarkMode
               ? "bg-gradient-to-r from-primary-500 to-accent-500 text-white shadow-[0_0_20px_rgba(139,92,246,0.7)] animate-glow"
@@ -213,7 +213,7 @@ const AboutUs = () => {
               enterprise.
             </p>
           </div>
-        </div>
+       
       </motion.section>
 
       {/* Mission Section */}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #352 

## Rationale for this change

The About page and Hero section had uneven spacing, which made the layout look inconsistent. Fixing these spacing issues improves readability and makes the design more balanced across the site.

## What changes are included in this PR?

- Removed extra margin on the P tag in the About page.
- Added margin before the About section box.
- Fixed spacing between h1 tag and p tag in the hero section.


## Are these changes tested?

  ☑️  Verified on Chrome Dev Tools with multiple device breakpoints (iPhone, Pixel, Galaxy).
  ☑️  Confirmed that desktop layout remains unaffected.

## Screenshot

<img width="1691" height="811" alt="updated_about_page" src="https://github.com/user-attachments/assets/c5e3c8f2-e6b9-483d-ace8-28cb1643ea2f" />


Kindly review and merge the PR and add the Level 1 label.



