### PR TITLE
Help Center button now redirects directly to the ‘Send a Message’ dialog box for quick help

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -317,6 +317,7 @@ const Contact = () => {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
             {/* Form - Takes 2 columns with Enhanced Glassmorphism */}
             <motion.div
+              id= "contact-info"
               variants={fadeIn("right", 0.7)}
               className={`lg:col-span-2 p-10 rounded-3xl backdrop-blur-xl border transition-all duration-500 ${
                 isDarkMode 

--- a/src/components/FAQ.jsx
+++ b/src/components/FAQ.jsx
@@ -323,7 +323,7 @@ export default function FAQ() {
           </motion.button>
 
           <motion.button
-            onClick={() => navigate("/help")}
+            onClick={() => navigate("/contact#contact-info")}
             className={`px-6 py-3 rounded-xl border font-semibold transition-all duration-300 ${
               isDarkMode
                 ? "border-gray-600 text-gray-300 hover:bg-gray-700 hover:text-white"


### PR DESCRIPTION
## Which issue does this PR close?

Closes #380 

## Rationale for this change
The "Browse Help Center" button in the support section was not functioning as intended. Instead of opening the Help Center, it redirected incorrectly.

As part of the fix, the button has now been redirected to the Contact Us page, which contains the "Send a Message" dialog box, ensuring users can still access support options seamlessly. This provides users with a direct way to raise queries, improving overall support accessibility.

## What changes are included in this PR?
Updated the "Browse Help Center" button to redirect to the Contact Us page.
Ensured that the Contact Us page loads with the "Send a Message" dialog box.
Verified that the button is functional and does not result in broken navigation.

## Are these changes tested?
Yes.
Manually tested on Windows 11 using Chrome 140.0.7339.80 (64-bit).
Confirmed that clicking the button redirects correctly to the Contact Us page with the "Send a Message" dialog box.

## Are there any user-facing changes?
Yes.
Users clicking the "Browse Help Center" button will now be redirected to the Contact Us page instead of the Help Center.
They will immediately see the "Send a Message" form, allowing them to contact support directly.

## Screenshot:
<img width="1888" height="902" alt="image" src="https://github.com/user-attachments/assets/ea05fe0e-26c4-48e7-904f-daeab08a156d" />

## Additional Context:
Kindly review and merge the PR. @adityadomle 