### PR TITLE
Removed duplicates

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -67,7 +67,6 @@ const ModernNavbar = () => {
     { href: "/#services", label: "Services", icon: <Zap className="w-4 h-4" /> },
     { href: "/#testimonials", label: "Testimonials", icon: <BookOpen className="w-4 h-4" /> },
     { href: "/#faq", label: "FAQ", icon: <BookOpen className="w-4 h-4" /> },
-    { href: "/contact", label: "Contact", icon: <Users className="w-4 h-4" /> },
   ], []);
 
   const dropdownItems = useMemo(() => [
@@ -535,7 +534,7 @@ const ModernNavbar = () => {
               `}
             >
               <Sparkles className="w-4 h-4" />
-              Get in Touch
+              Contact Us
             </button>
           </div>
 


### PR DESCRIPTION

## Which issue does this PR close?

Closes #393 

## Rationale for this change

Both **Contact** and **Get in Touch** menu items navigated to the same page. Having two redundant links was confusing for users, so this PR removes the duplicate to improve navigation clarity.

## What changes are included in this PR?

* Removed one of the duplicate navigation items (kept a single clear link).
* Updated navigation component accordingly.

## Are these changes tested?

* Yes, verified manually that navigation now works correctly and only one link is present.

## Are there any user-facing changes?

* Yes, users will now see only **one link** (“Contact”) instead of two different ones pointing to the same page.

---

👉 Then when you open the PR, add the **labels**:

* `GSSoC25`
* `LEVEL 1`
